### PR TITLE
Add react-component blueprint

### DIFF
--- a/blueprints/react-component/files/__root__/__path__/__name__.jsx
+++ b/blueprints/react-component/files/__root__/__path__/__name__.jsx
@@ -1,0 +1,9 @@
+import React from 'npm:react';
+
+<%= prefix %> <%= camelizedModuleName %> <%= contents %>
+
+<%= camelizedModuleName %>.propTypes = {
+
+};
+
+export default <%= camelizedModuleName %>;

--- a/blueprints/react-component/index.js
+++ b/blueprints/react-component/index.js
@@ -1,0 +1,83 @@
+/*jshint node:true*/
+
+var stringUtil         = require('ember-cli-string-utils');
+var pathUtil           = require('ember-cli-path-utils');
+var validComponentName = require('ember-cli-valid-component-name');
+var getPathOption      = require('ember-cli-get-component-path-option');
+var path               = require('path');
+
+var normalizeEntityName = require('ember-cli-normalize-entity-name');
+
+var templates = {
+  func: '= props => {\n\n\treturn (\n\t\t<div></div>\n\t);\n};',
+  class: 'extends React.Component {\n\trender() {\n\t\treturn (\n\t\t\t<div></div>\n\t\t);\n\t}\n};',
+  blockless: '= props => \n\t(\n\t\t<div></div>\n\t);'
+}
+
+module.exports = {
+  description: 'Generates a react component. Name must contain a hyphen.',
+
+  availableOptions: [
+    {
+      name: 'type',
+      type: String,
+      default: 'class',
+      aliases:[
+        {'func': 'function'},
+        {'no-block': 'blockless-function'}
+      ]
+    }
+  ],
+
+  fileMapTokens: function() {
+    return {
+      __path__: function(options) {
+        return 'components';
+      }
+    };
+  },
+
+  normalizeEntityName: function(entityName) {
+    entityName = normalizeEntityName(entityName);
+
+    return validComponentName(entityName);
+  },
+
+  locals: function(attrs) {
+    options = attrs.entity.options;
+    var prefix = 'const';
+    if (Object.keys(options).indexOf('func') !== -1) {
+      return {
+        prefix: prefix,
+        contents: templates.func
+      }
+    }
+
+    if (Object.keys(options).indexOf('no-block') !== -1) {
+      return {
+        prefix: prefix,
+        contents: templates.blockless
+      }
+    }
+
+    if (Object.keys(options).indexOf('type') !== -1) {
+      if (options.type === 'function' || options.type === 'func') {
+        return {
+          prefix: prefix,
+          contents: templates.func
+        }
+      }
+      if (options.type === 'blockless-function' || options.type === 'no-block') {
+        return {
+          prefix: prefix,
+          contents: templates.blockless
+        }
+      }
+    }
+
+    return {
+      prefix: 'class',
+      contents: templates.class
+    };
+  }
+};

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ var react = require('broccoli-react');
 
 module.exports = {
   name: 'ember-cli-react',
-
   preprocessTree: function(type, tree) {
     if (type === 'js') {
       tree = react(tree, { transform: { es6module: true } } );


### PR DESCRIPTION
Hello!

I am just added react-component blueprint for ember generator for self, but you can merge this PR for all :)

Usage:
`ember generate react-component <component-name> [options]`

Blueprint has 3 different templates:
 - Class component(Default)
 - Function conponent
 - Block-less function component

```js
import React from 'npm:react';

class xButton extends React.Component {
	render() {
		return (
			<div></div>
		);
	}
};

xButton.propTypes = {

};

export default xButton;

```

```js
import React from 'npm:react';

const xButton = props => {

	return (
		<div></div>
	);
};

xButton.propTypes = {

};

export default xButton;

```

```js
import React from 'npm:react';

const xButton = props => 
	(
		<div></div>
	);

xButton.propTypes = {

};

export default xButton;

```