### PR TITLE
Update React to ^15.5.4

### DIFF
--- a/blueprints/ember-cli-react/index.js
+++ b/blueprints/ember-cli-react/index.js
@@ -1,6 +1,14 @@
 /*jshint node:true*/
 
 var RSVP = require('rsvp');
+var pkg = require('../../package.json');
+
+function getDependencyVersion(packageJson, name) {
+  var dependencies = packageJson.dependencies;
+  var devDependencies = packageJson.devDependencies;
+
+  return dependencies[name] || devDependencies[name];
+}
 
 module.exports = {
   description: 'Install ember-cli-react dependencies into your app.',
@@ -10,9 +18,9 @@ module.exports = {
   // Install react into host app
   afterInstall: function() {
     return RSVP.all([
-      this.addPackageToProject("ember-browserify", "^1.1.7"),
-      this.addPackageToProject("react", "^0.14.7"),
-      this.addPackageToProject("react-dom", "^0.14.7")
+      this.addPackageToProject("ember-browserify", getDependencyVersion(pkg, "ember-browserify")),
+      this.addPackageToProject("react", getDependencyVersion(pkg, "react")),
+      this.addPackageToProject("react-dom", getDependencyVersion(pkg, "react-dom"))
     ]);
   }
 };

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-dom": "^15.5.4"
   },
   "dependencies": {
-    "broccoli-react": "https://github.com/pswai/broccoli-react.git",
+    "broccoli-react": "^0.8.0",
     "ember-cli-babel": "^6.0.0",
     "rsvp": "^3.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "ember-sinon": "0.5.0",
     "ember-source": "~2.13.0",
     "loader.js": "^4.2.3",
-    "react": "^0.14.7",
-    "react-dom": "^0.14.7"
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4"
   },
   "dependencies": {
     "broccoli-react": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-dom": "^15.5.4"
   },
   "dependencies": {
-    "broccoli-react": "^0.7.1",
+    "broccoli-react": "https://github.com/pswai/broccoli-react.git",
     "ember-cli-babel": "^6.0.0",
     "rsvp": "^3.2.1"
   },


### PR DESCRIPTION
This updates React to ^15.5.4.

It works with current `broccoli-react` that utilises `react-tools` but it will be better if we can use babel instead.

PR for `broccoli-react` to use babel: https://github.com/eddhannay/broccoli-react/pull/8