### PR TITLE
Fix Ember version check

### DIFF
--- a/addon/utils/get-mutable-attributes.js
+++ b/addon/utils/get-mutable-attributes.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
-const emberMajorMinorVersion = Ember.VERSION.match(/(\d+\.\d+)\.*/)[1];
-const isGlimmer = Number(emberMajorMinorVersion) >= 2.10;
+const [major, minor] = Ember.VERSION.split('.');
+const isGlimmer = major >= 2 && minor >= 10; // >= 2.10
 
 let getMutValue;
 


### PR DESCRIPTION
The original check does not work properly for Ember < 2.10. For example `2.6 >= 2.10` gives `true`.