### PR TITLE
Upgrade ember-cli to 2.15.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
 /dist
@@ -13,6 +13,12 @@
 /connect.lock
 /coverage/*
 /libpeerconnection.log
-npm-debug.log
+npm-debug.log*
+yarn-error.log
 testem.log
 .vscode
+
+# ember-try
+.node_modules.ember-try/
+bower.json.ember-try
+package.json.ember-try

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,60 +2,82 @@
 module.exports = {
   scenarios: [
     {
-      name: 'ember-1.13',
+      name: 'ember-lts-2.8',
       bower: {
         dependencies: {
-          ember: '~1.13.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2.10',
-      bower: {
-        dependencies: {
-          ember: '~2.10.0'
-        }
-      }
+          ember: 'components/ember#lts-2-8',
+        },
+        resolutions: {
+          ember: 'lts-2-8',
+        },
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null,
+        },
+      },
     },
     {
       name: 'ember-lts-2.12',
       npm: {
         devDependencies: {
-          'ember-source': '~2.12.0'
-        }
-      }
+          'ember-source': '~2.12.0',
+        },
+      },
     },
     {
-      name: 'ember-lts-2.16',
+      name: 'ember-release',
+      bower: {
+        dependencies: {
+          ember: 'components/ember#release',
+        },
+        resolutions: {
+          ember: 'release',
+        },
+      },
       npm: {
         devDependencies: {
-          'ember-source': '~2.16.0'
-        }
-      }
+          'ember-source': null,
+        },
+      },
     },
     {
-      name: 'ember-lts-2.18',
+      name: 'ember-beta',
+      bower: {
+        dependencies: {
+          ember: 'components/ember#beta',
+        },
+        resolutions: {
+          ember: 'beta',
+        },
+      },
       npm: {
         devDependencies: {
-          'ember-source': '~2.18.0'
-        }
-      }
+          'ember-source': null,
+        },
+      },
     },
     {
-      name: 'ember-3.0.x',
+      name: 'ember-canary',
+      bower: {
+        dependencies: {
+          ember: 'components/ember#canary',
+        },
+        resolutions: {
+          ember: 'canary',
+        },
+      },
       npm: {
         devDependencies: {
-          'ember-source': '~3.0.0'
-        }
-      }
+          'ember-source': null,
+        },
+      },
     },
     {
-      name: 'ember-3.1.x',
+      name: 'ember-default',
       npm: {
-        devDependencies: {
-          'ember-source': '~3.1.0'
-        }
-      }
-    }
-  ]
+        devDependencies: {},
+      },
+    },
+  ],
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,9 +1,10 @@
-/*jshint node:true*/
-/* global require, module */
-var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+/* eslint-env node */
+'use strict';
+
+const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
-  var app = new EmberAddon(defaults, {
+  let app = new EmberAddon(defaults, {
     'ember-cli-babel': {
       includePolyfill: true,
     },

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-/* jshint node: true */
+/* eslint-env node */
 'use strict';
 
-var react = require('broccoli-react');
+const react = require('broccoli-react');
 
 module.exports = {
   name: 'ember-cli-react',

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "ember-cli-react",
   "version": "0.3.1",
   "description": "Use React component hierarchies in your Ember app.",
-  "keywords": ["ember-addon"],
+  "keywords": [
+    "ember-addon"
+  ],
   "directories": {
     "doc": "doc",
     "test": "tests"
@@ -14,7 +16,11 @@
     "precommit": "lint-staged"
   },
   "lint-staged": {
-    "*.{js,jsx}": ["prettier --write", "eslint --fix", "git add"],
+    "*.{js,jsx}": [
+      "prettier --write",
+      "eslint --fix",
+      "git add"
+    ],
     "+(*.{json,css}|.prettierrc|.watchmanconfig)": [
       "prettier --write",
       "git add"
@@ -30,27 +36,26 @@
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^3.0.0",
     "ember-browserify": "^1.1.7",
-    "ember-cli": "2.13.1",
+    "ember-cli": "~2.15.1",
     "ember-cli-chai": "^0.4.1",
-    "ember-cli-dependency-checker": "^1.3.0",
-    "ember-cli-eslint": "^3.0.0",
-    "ember-cli-htmlbars": "^1.1.1",
-    "ember-cli-htmlbars-inline-precompile": "^0.4.0",
+    "ember-cli-dependency-checker": "^2.0.0",
+    "ember-cli-eslint": "^4.0.0",
+    "ember-cli-htmlbars": "^2.0.1",
+    "ember-cli-htmlbars-inline-precompile": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-mocha": "^0.14.3",
     "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",
-    "ember-cli-test-loader": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-disable-prototype-extensions": "^1.1.0",
+    "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
     "ember-sinon": "0.5.0",
-    "ember-source": "~2.13.0",
+    "ember-source": "~2.15.0",
     "eslint": "^4.11.0",
     "eslint-config-prettier": "^2.7.0",
-    "eslint-plugin-prettier": "^2.3.1",
+    "eslint-plugin-prettier": "2.6.0",
     "eslint-plugin-react": "^7.5.1",
     "husky": "^0.14.3",
     "lint-staged": "^5.0.0",
@@ -62,7 +67,7 @@
   "dependencies": {
     "bower": "^1.8.2",
     "broccoli-react": "^0.8.0",
-    "ember-cli-babel": "^6.0.0",
+    "ember-cli-babel": "^6.3.0",
     "rsvp": "^3.2.1"
   },
   "ember-addon": {

--- a/testem.js
+++ b/testem.js
@@ -1,8 +1,15 @@
-/*jshint node:true*/
+/* eslint-env node */
 module.exports = {
-  framework: 'qunit',
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
   launch_in_ci: ['Chrome'],
-  launch_in_dev: ['PhantomJS', 'Chrome'],
+  launch_in_dev: ['Chrome'],
+  browser_args: {
+    Chrome: [
+      '--disable-gpu',
+      '--headless',
+      '--remote-debugging-port=9222',
+      '--window-size=1440,900',
+    ],
+  },
 };

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -3,11 +3,7 @@ import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
-let App;
-
-Ember.MODEL_FACTORY_INJECTIONS = true;
-
-App = Ember.Application.extend({
+const App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver,

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -9,16 +9,16 @@
 
     {{content-for "head"}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/dummy.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/dummy.css">
 
     {{content-for "head-footer"}}
   </head>
   <body>
     {{content-for "body"}}
 
-    <script src="assets/vendor.js"></script>
-    <script src="assets/dummy.js"></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/dummy.js"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -3,6 +3,7 @@ import config from './config/environment';
 
 const Router = Ember.Router.extend({
   location: config.locationType,
+  rootURL: config.rootURL,
 });
 
 Router.map(function() {});

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -1,15 +1,20 @@
-/* jshint node: true */
+/* eslint-env node */
+'use strict';
 
 module.exports = function(environment) {
-  var ENV = {
+  let ENV = {
     modulePrefix: 'dummy',
-    environment: environment,
-    baseURL: '/',
+    environment,
+    rootURL: '/',
     locationType: 'auto',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
         // e.g. 'with-controller': true
+      },
+      EXTEND_PROTOTYPES: {
+        // Prevent Ember Data from overriding Date.parse.
+        Date: false,
       },
     },
 
@@ -29,7 +34,6 @@ module.exports = function(environment) {
 
   if (environment === 'test') {
     // Testem prefers this...
-    ENV.baseURL = '/';
     ENV.locationType = 'none';
 
     // keep test console output quieter
@@ -37,6 +41,10 @@ module.exports = function(environment) {
     ENV.APP.LOG_VIEW_LOOKUPS = false;
 
     ENV.APP.rootElement = '#ember-testing';
+  }
+
+  if (environment === 'production') {
+    // Production settings
   }
 
   return ENV;

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,6 +1,11 @@
 import { module } from 'qunit';
+import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
+
+const {
+  RSVP: { resolve },
+} = Ember;
 
 export default function(name, options = {}) {
   module(name, {
@@ -8,16 +13,14 @@ export default function(name, options = {}) {
       this.application = startApp();
 
       if (options.beforeEach) {
-        options.beforeEach.apply(this, arguments);
+        return options.beforeEach.apply(this, arguments);
       }
     },
 
     afterEach() {
-      if (options.afterEach) {
-        options.afterEach.apply(this, arguments);
-      }
-
-      destroyApp(this.application);
+      let afterEach =
+        options.afterEach && options.afterEach.apply(this, arguments);
+      return resolve(afterEach).then(() => destroyApp(this.application));
     },
   });
 }

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -3,16 +3,13 @@ import Application from '../../app';
 import config from '../../config/environment';
 
 export default function startApp(attrs) {
-  let application;
-
   let attributes = Ember.merge({}, config.APP);
   attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
 
-  Ember.run(() => {
-    application = Application.create(attributes);
+  return Ember.run(() => {
+    let application = Application.create(attributes);
     application.setupForTesting();
     application.injectTestHelpers();
+    return application;
   });
-
-  return application;
 }

--- a/tests/index.html
+++ b/tests/index.html
@@ -21,12 +21,11 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
-    <script src="testem.js" integrity=""></script>
+    <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>
     <script src="{{rootURL}}assets/dummy.js"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
-    <script src="{{rootURL}}assets/test-loader.js"></script>
 
     {{content-for "body-footer"}}
     {{content-for "test-body-footer"}}


### PR DESCRIPTION
I am in the process of adding use case of utilising React components from external libraries. The good news is that it is working great! However, we need to upgrade our ember-cli version.

First, we need to pin our eslint-plugin-prettier at 2.6.0, since there is a bug in 2.6.1 that breaks everything. https://github.com/ember-cli/ember-cli-eslint/issues/235

Second, I would like to import something via ember-cli-build.js but `app.import` does not support `node_modules` until 2.15. So I am upgrading here to make it works :)
https://github.com/ember-cli/ember-cli.github.io/issues/175