### PR TITLE
Replace `ember-browserify` with `ember-auto-import`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**This is ALPHA Software**
+**Experimental Addon**
 
 This was built as a prototype to evaluate using react inside of our Ember apps. We are not yet using it in production. PRs and constructive questions and comments via [GitHub issues](https://github.com/AltSchool/ember-cli-react/issues/new) are highly encouraged.
 
@@ -7,9 +7,9 @@ This was built as a prototype to evaluate using react inside of our Ember apps. 
 [![Circle CI](https://circleci.com/gh/AltSchool/ember-cli-react.svg?style=shield)](https://circleci.com/gh/AltSchool/ember-cli-react)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 
-Use React component hierarchies inside your Ember app.
+Use clean React component hierarchies inside your Ember app.
 
-## Overview
+## Install
 
 Install the addon in your app:
 
@@ -17,15 +17,30 @@ Install the addon in your app:
 ember install ember-cli-react
 ```
 
-Write your first JSX React component:
+If you prefer npm/yarn install (the following is similar with above):
+
+```
+yarn add --dev ember-cli-react
+
+# This triggers addon blueprint to do necessary setup
+ember generate ember-cli-react
+```
+
+**NOTE**:
+`ember-cli-react` relies on a custom resolver to discover components. If you have
+installed `ember-cli-react` with the standard way then you should be fine. Otherwise, you will need to manually update the first line of `app/resolver.js` to `import Resolver from 'ember-cli-react/resolver';`.
+
+## Usage
+
+Write your React component as usual:
 
 ```javascript
 // app/components/say-hi.jsx
 import React from 'react';
 
-export default function(props) {
-  return <span>Hello {props.name}</span>;
-}
+const SayHi = props => <span>Hello {props.name}</span>;
+
+export default SayHi;
 ```
 
 Then render your component in a handlebars template:
@@ -34,14 +49,11 @@ Then render your component in a handlebars template:
 {{say-hi name="Alex"}}
 ```
 
-**NOTE**: If you install `ember-cli-react` using npm or yarn install, instead of
-the ember install command, then you will need to manually update the first line
-of `app/resolver.js` to `import Resolver from 'ember-cli-react/resolver';`.
+**NOTE**: Currently, `ember-cli-react` recognizes React components with `.jsx` extension only.
 
 ## Block Form
 
-Your React component can be used in block form to allow composition with existing
-Ember or React components.
+Your React component can be used in block form to allow composition with existing Ember or React components.
 
 ```handlebars
 {{#react-panel}}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Write your first JSX React component:
 
 ```javascript
 // app/components/say-hi.jsx
-import React from 'npm:react';
+import React from 'react';
 
 export default function(props) {
   return <span>Hello {props.name}</span>;
@@ -124,7 +124,7 @@ export default Ember.Controller.extend({
 #### app/components/todo-list.jsx
 
 ```jsx
-import React from 'npm:react';
+import React from 'react';
 import TodoItem from './todo-item';
 
 export default function(props) {
@@ -141,8 +141,8 @@ export default function(props) {
 #### app/components/todo-item.jsx
 
 ```jsx
-import React from 'npm:react';
-import ReactDOM from 'npm:react-dom';
+import React from 'react';
+import ReactDOM from 'react-dom';
 
 export default class TodoItem extends React.Component {
   render() {

--- a/addon/components/react-component.js
+++ b/addon/components/react-component.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import React from 'npm:react';
-import ReactDOM from 'npm:react-dom';
+import React from 'react';
+import ReactDOM from 'react-dom';
 import YieldWrapper from './react-component/yield-wrapper';
 
 import getMutableAttributes from 'ember-cli-react/utils/get-mutable-attributes';

--- a/addon/components/react-component/yield-wrapper.js
+++ b/addon/components/react-component/yield-wrapper.js
@@ -1,4 +1,4 @@
-import React from 'npm:react';
+import React from 'react';
 
 /**
  * A React component that is used to render HTML Nodes.

--- a/app/components/react-component.js
+++ b/app/components/react-component.js
@@ -1,8 +1,1 @@
-// Must import browserified dependencies from `app/`
-// https://github.com/ef4/ember-browserify#using-ember-browserify-in-addons
-/* eslint-disable no-unused-vars */
-import React from 'react';
-import ReactDOM from 'react-dom';
-/* eslint-enable no-unused-vars */
-
 export { default } from 'ember-cli-react/components/react-component';

--- a/app/components/react-component.js
+++ b/app/components/react-component.js
@@ -1,8 +1,8 @@
 // Must import browserified dependencies from `app/`
 // https://github.com/ef4/ember-browserify#using-ember-browserify-in-addons
 /* eslint-disable no-unused-vars */
-import React from 'npm:react';
-import ReactDOM from 'npm:react-dom';
+import React from 'react';
+import ReactDOM from 'react-dom';
 /* eslint-enable no-unused-vars */
 
 export { default } from 'ember-cli-react/components/react-component';

--- a/blueprints/ember-cli-react/index.js
+++ b/blueprints/ember-cli-react/index.js
@@ -2,13 +2,6 @@
 
 var pkg = require('../../package.json');
 
-function getDependencyVersion(packageJson, name) {
-  var dependencies = packageJson.dependencies;
-  var devDependencies = packageJson.devDependencies;
-
-  return dependencies[name] || devDependencies[name];
-}
-
 function getPeerDependencyVersion(packageJson, name) {
   var peerDependencies = packageJson.peerDependencies;
 
@@ -23,10 +16,6 @@ module.exports = {
   // Install react into host app
   afterInstall: function() {
     const packages = [
-      {
-        name: 'ember-auto-import',
-        target: getDependencyVersion(pkg, 'ember-auto-import'),
-      },
       {
         name: 'react',
         target: getPeerDependencyVersion(pkg, 'react'),

--- a/blueprints/ember-cli-react/index.js
+++ b/blueprints/ember-cli-react/index.js
@@ -1,5 +1,24 @@
 /*jshint node:true*/
 
+var pkg = require('../../package.json');
+
+function getDependencyVersion(packageJson, name) {
+  var dependencies = packageJson.dependencies;
+  var devDependencies = packageJson.devDependencies;
+
+  return dependencies[name] || devDependencies[name];
+}
+
 module.exports = {
   description: 'Install ember-cli-react dependencies into your app.',
+
+  normalizeEntityName: function() {},
+
+  // Install react into host app
+  afterInstall: function() {
+    return this.addPackageToProject(
+      'ember-auto-import',
+      getDependencyVersion(pkg, 'ember-auto-import')
+    );
+  },
 };

--- a/blueprints/ember-cli-react/index.js
+++ b/blueprints/ember-cli-react/index.js
@@ -9,6 +9,12 @@ function getDependencyVersion(packageJson, name) {
   return dependencies[name] || devDependencies[name];
 }
 
+function getPeerDependencyVersion(packageJson, name) {
+  var peerDependencies = packageJson.peerDependencies;
+
+  return peerDependencies[name];
+}
+
 module.exports = {
   description: 'Install ember-cli-react dependencies into your app.',
 
@@ -16,9 +22,20 @@ module.exports = {
 
   // Install react into host app
   afterInstall: function() {
-    return this.addPackageToProject(
-      'ember-auto-import',
-      getDependencyVersion(pkg, 'ember-auto-import')
-    );
+    const packages = [
+      {
+        name: 'ember-auto-import',
+        target: getDependencyVersion(pkg, 'ember-auto-import'),
+      },
+      {
+        name: 'react',
+        target: getPeerDependencyVersion(pkg, 'react'),
+      },
+      {
+        name: 'react-dom',
+        target: getPeerDependencyVersion(pkg, 'react-dom'),
+      },
+    ];
+    return this.addPackagesToProject(packages);
   },
 };

--- a/blueprints/ember-cli-react/index.js
+++ b/blueprints/ember-cli-react/index.js
@@ -1,32 +1,5 @@
 /*jshint node:true*/
 
-var RSVP = require('rsvp');
-var pkg = require('../../package.json');
-
-function getDependencyVersion(packageJson, name) {
-  var dependencies = packageJson.dependencies;
-  var devDependencies = packageJson.devDependencies;
-
-  return dependencies[name] || devDependencies[name];
-}
-
 module.exports = {
   description: 'Install ember-cli-react dependencies into your app.',
-
-  normalizeEntityName: function() {},
-
-  // Install react into host app
-  afterInstall: function() {
-    return RSVP.all([
-      this.addPackageToProject(
-        'ember-browserify',
-        getDependencyVersion(pkg, 'ember-browserify')
-      ),
-      this.addPackageToProject('react', getDependencyVersion(pkg, 'react')),
-      this.addPackageToProject(
-        'react-dom',
-        getDependencyVersion(pkg, 'react-dom')
-      ),
-    ]);
-  },
 };

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^3.0.0",
-    "ember-auto-import": "^1.0.1",
     "ember-cli": "~2.15.1",
     "ember-cli-chai": "^0.4.1",
     "ember-cli-dependency-checker": "^2.0.0",
@@ -60,13 +59,14 @@
     "husky": "^0.14.3",
     "lint-staged": "^5.0.0",
     "loader.js": "^4.2.3",
-    "prettier": "^1.9.2",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4"
+    "prettier": "^1.9.2"
   },
   "dependencies": {
     "broccoli-react": "^0.8.0",
-    "ember-cli-babel": "^6.3.0"
+    "ember-auto-import": "^1.0.1",
+    "ember-cli-babel": "^6.3.0",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4"
   },
   "peerDependencies": {
     "react": "^15.5.4 || ^16.0.0",

--- a/package.json
+++ b/package.json
@@ -65,10 +65,12 @@
     "react-dom": "^15.5.4"
   },
   "dependencies": {
-    "bower": "^1.8.2",
     "broccoli-react": "^0.8.0",
-    "ember-cli-babel": "^6.3.0",
-    "rsvp": "^3.2.1"
+    "ember-cli-babel": "^6.3.0"
+  },
+  "peerDependencies": {
+    "react": "^15.5.4 || ^16.0.0",
+    "react-dom": "^15.5.4 || ^16.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^3.0.0",
-    "ember-browserify": "^1.1.7",
+    "ember-auto-import": "^1.0.1",
     "ember-cli": "~2.15.1",
     "ember-cli-chai": "^0.4.1",
     "ember-cli-dependency-checker": "^2.0.0",

--- a/tests/dummy/app/components/facc-wrapper.jsx
+++ b/tests/dummy/app/components/facc-wrapper.jsx
@@ -1,4 +1,4 @@
-import React from 'npm:react';
+import React from 'react';
 
 const FaccWrapper = props => {
   return <span>Warning: {props.children('supported but anti-pattern')}</span>;

--- a/tests/dummy/app/components/fancy-button.jsx
+++ b/tests/dummy/app/components/fancy-button.jsx
@@ -1,4 +1,4 @@
-import React from 'npm:react';
+import React from 'react';
 
 const FancyButton = props => {
   return (

--- a/tests/dummy/app/components/no-yield-wrapper-with-own-children.jsx
+++ b/tests/dummy/app/components/no-yield-wrapper-with-own-children.jsx
@@ -1,4 +1,4 @@
-import React from 'npm:react';
+import React from 'react';
 
 const NoYieldWrapperWithOwnChildren = props => {
   if (React.Children.count(props.children)) {

--- a/tests/dummy/app/components/no-yield-wrapper-with-props.jsx
+++ b/tests/dummy/app/components/no-yield-wrapper-with-props.jsx
@@ -1,4 +1,4 @@
-import React from 'npm:react';
+import React from 'react';
 
 const NoYieldWrapperWithProps = props => {
   const { text, children } = props;

--- a/tests/dummy/app/components/no-yield-wrapper.jsx
+++ b/tests/dummy/app/components/no-yield-wrapper.jsx
@@ -1,4 +1,4 @@
-import React from 'npm:react';
+import React from 'react';
 
 export default function NoYieldWrapper(props) {
   if (React.Children.count(props.children)) {

--- a/tests/dummy/app/components/say-hi.jsx
+++ b/tests/dummy/app/components/say-hi.jsx
@@ -1,4 +1,4 @@
-import React from 'npm:react';
+import React from 'react';
 
 const SayHi = props => {
   return <span className="SayHi">Hello {props.name}</span>;

--- a/tests/dummy/app/components/the-wrapper.jsx
+++ b/tests/dummy/app/components/the-wrapper.jsx
@@ -1,4 +1,4 @@
-import React from 'npm:react';
+import React from 'react';
 
 const TheWrapper = props => {
   return <span>Content: {props.children}</span>;

--- a/tests/dummy/app/components/todo-item.jsx
+++ b/tests/dummy/app/components/todo-item.jsx
@@ -1,4 +1,4 @@
-import React from 'npm:react';
+import React from 'react';
 
 class TodoItem extends React.Component {
   render() {

--- a/tests/dummy/app/components/todo-list.jsx
+++ b/tests/dummy/app/components/todo-list.jsx
@@ -1,4 +1,4 @@
-import React from 'npm:react';
+import React from 'react';
 import TodoItem from './todo-item';
 
 const TodoList = props => {

--- a/tests/integration/components/react-component-test.js
+++ b/tests/integration/components/react-component-test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { describeComponent, it } from 'ember-mocha';
 import { describe } from 'mocha';
 import Ember from 'ember';
-import React from 'npm:react';
+import React from 'react';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 


### PR DESCRIPTION
## THIS IS A BREAKING CHANGE

### What has been done
- Replace `ember-browserify` with `ember-auto-import`
- Made React and ReactDom peer dependencies and stop installing them automatically
- Updated blueprint
- Updated readme

### Story

`ember-browserify` has been deprecated and replaced by `ember-auto-import`.
https://github.com/ef4/ember-auto-import

Though still working, it is ugly to import something with `ember-browserify` since we need the `npm:` prefix:
```javascript
import React from 'npm:react';
```

With `ember-auto-import`, we can just do
```javascript
import React from 'react';
```

And this is a HUGE win! Now users can write their React components in 100% clean way.

Old way:
```javascript
import React from 'npm:react';

const Foo = () => <div>foo</div>;
export default Foo;
```

New way:
```javascript
import React from 'react';

const Foo = () => <div>foo</div>;
export default Foo;
```

This is especially valuable for projects that aim to completely migrate out of Ember.

Together with this, React and ReactDom is made peer dependencies. This allows users to use any version of React that is suitable for their project.

### Migration Path
For existing users, these are the changes expected:
- Remove `ember-browserify` from package.json (if no other addon is using)
- Install latest `ember-cli-react` with blueprint triggered
- Remove all `npm:` prefix
