### PR TITLE
Add `hasBlock` to check component to decide whether to create YieldWrapper

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
     es6: true,
     node: true,
     browser: true,
+    mocha: true,
   },
   rules: {
     'prettier/prettier': 'warn',

--- a/addon/components/react-component.js
+++ b/addon/components/react-component.js
@@ -4,6 +4,7 @@ import ReactDOM from 'npm:react-dom';
 import YieldWrapper from './react-component/yield-wrapper';
 
 import getMutableAttributes from 'ember-cli-react/utils/get-mutable-attributes';
+import hasBlock from 'ember-cli-react/utils/has-block';
 import lookupFactory from 'ember-cli-react/utils/lookup-factory';
 
 const { get } = Ember;
@@ -57,8 +58,15 @@ const ReactComponent = Ember.Component.extend({
     if (!children) {
       const childNodes = get(this, 'element.childNodes');
 
-      // We do not need to do anything if there is no child nodes
-      if (childNodes.length > 0) {
+      // In Ember 2.8, an empty comment node is still created for non-block form
+      // component. This behavior breaks any component that does not expect
+      // children to exist.
+      // We can safely assume that there is no child node if:
+      // - The component is not in block form
+      // - There is no child node (of course)
+
+      // For other cases, we need to create a YieldWrapper to hold the nodes
+      if (hasBlock(this) && childNodes.length > 0) {
         children = [
           React.createElement(YieldWrapper, {
             key: get(this, 'elementId'),

--- a/addon/utils/ember-version-info.js
+++ b/addon/utils/ember-version-info.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+const emberVersionInfo = () => {
+  const [major, minor] = Ember.VERSION.split('.');
+  const isGlimmer = major > 2 || (major == 2 && minor >= 10); // >= 2.10
+  return { major, minor, isGlimmer };
+};
+
+export default emberVersionInfo;

--- a/addon/utils/get-mutable-attributes.js
+++ b/addon/utils/get-mutable-attributes.js
@@ -6,7 +6,12 @@ const isGlimmer = major > 2 || (major == 2 && minor >= 10); // >= 2.10
 let getMutValue;
 
 if (isGlimmer) {
-  const { MUTABLE_CELL } = Ember.__loader.require('ember-views/compat/attrs');
+  // The module location changed since v3.2
+  let libPath =
+    major == 3 && minor >= 2
+      ? 'ember-views/lib/compat/attrs'
+      : 'ember-views/compat/attrs';
+  const { MUTABLE_CELL } = Ember.__loader.require(libPath);
   getMutValue = value => {
     if (value && value[MUTABLE_CELL]) {
       return value.value;

--- a/addon/utils/get-mutable-attributes.js
+++ b/addon/utils/get-mutable-attributes.js
@@ -1,14 +1,14 @@
 import Ember from 'ember';
+import emberVersionInfo from './ember-version-info';
 
-const [major, minor] = Ember.VERSION.split('.');
-const isGlimmer = major > 2 || (major == 2 && minor >= 10); // >= 2.10
+const { major, minor, isGlimmer } = emberVersionInfo();
 
 let getMutValue;
 
 if (isGlimmer) {
   // The module location changed since v3.2
   let libPath =
-    major == 3 && minor >= 2
+    major > 3 || (major == 3 && minor >= 2)
       ? 'ember-views/lib/compat/attrs'
       : 'ember-views/compat/attrs';
   const { MUTABLE_CELL } = Ember.__loader.require(libPath);

--- a/addon/utils/has-block.js
+++ b/addon/utils/has-block.js
@@ -1,0 +1,30 @@
+import Ember from 'ember';
+
+const [major, minor] = Ember.VERSION.split('.');
+const isGlimmer = major > 2 || (major == 2 && minor >= 10); // >= 2.10
+
+let hasBlockSymbol;
+
+if (major == 3 && minor >= 1) {
+  // do nothing since the symbol is not exported
+} else if (isGlimmer) {
+  hasBlockSymbol = Ember.__loader.require('ember-glimmer/component')[
+    'HAS_BLOCK'
+  ];
+} else {
+  hasBlockSymbol = Ember.__loader.require('ember-htmlbars/component')[
+    'HAS_BLOCK'
+  ];
+}
+
+// NOTE: I really don't know how to test this
+export default function hasBlock(emberComponent) {
+  // Since Glimmer moved to TypeScript, we can't get the symbol.
+  // This is a terrible but working way to get the value.
+  if (!hasBlockSymbol) {
+    const regex = /HAS_BLOCK/;
+    hasBlockSymbol = Object.keys(emberComponent).find(key => regex.test(key));
+  }
+
+  return Ember.get(emberComponent, hasBlockSymbol);
+}

--- a/addon/utils/has-block.js
+++ b/addon/utils/has-block.js
@@ -23,7 +23,9 @@ export default function hasBlock(emberComponent) {
   // This is a terrible but working way to get the value.
   if (!hasBlockSymbol) {
     const regex = /HAS_BLOCK/;
-    hasBlockSymbol = Object.keys(emberComponent).find(key => regex.test(key));
+    hasBlockSymbol = Object.getOwnPropertyNames(emberComponent).find(key =>
+      regex.test(key)
+    );
   }
 
   return Ember.get(emberComponent, hasBlockSymbol);

--- a/addon/utils/has-block.js
+++ b/addon/utils/has-block.js
@@ -1,12 +1,13 @@
 import Ember from 'ember';
+import emberVersionInfo from './ember-version-info';
 
-const [major, minor] = Ember.VERSION.split('.');
-const isGlimmer = major > 2 || (major == 2 && minor >= 10); // >= 2.10
+const { major, minor, isGlimmer } = emberVersionInfo();
 
 let hasBlockSymbol;
 
-if (major == 3 && minor >= 1) {
-  // do nothing since the symbol is not exported
+if (major > 3 || (major == 3 && minor >= 1)) {
+  // Ember-glimmer moved to TypeScript since v3.1
+  // Do nothing since the symbol is not exported
 } else if (isGlimmer) {
   hasBlockSymbol = Ember.__loader.require('ember-glimmer/component')[
     'HAS_BLOCK'

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,6 +2,22 @@
 module.exports = {
   scenarios: [
     {
+      name: 'ember-1.13',
+      bower: {
+        dependencies: {
+          ember: '~1.13.0',
+        },
+      },
+    },
+    {
+      name: 'ember-lts-2.4',
+      bower: {
+        dependencies: {
+          ember: '~2.4.0',
+        },
+      },
+    },
+    {
       name: 'ember-lts-2.8',
       bower: {
         dependencies: {
@@ -17,11 +33,60 @@ module.exports = {
         },
       },
     },
+    // Glimmer was introduced in v2.10, so better test it
+    {
+      name: 'ember-2.10',
+      bower: {
+        dependencies: {
+          ember: '~2.10.0',
+        },
+      },
+    },
     {
       name: 'ember-lts-2.12',
       npm: {
         devDependencies: {
           'ember-source': '~2.12.0',
+        },
+      },
+    },
+    {
+      name: 'ember-lts-2.16',
+      npm: {
+        devDependencies: {
+          'ember-source': '~2.16.0',
+        },
+      },
+    },
+    {
+      name: 'ember-lts-2.18',
+      npm: {
+        devDependencies: {
+          'ember-source': '~2.18.0',
+        },
+      },
+    },
+    {
+      name: 'ember-3.0.x',
+      npm: {
+        devDependencies: {
+          'ember-source': '~3.0.0',
+        },
+      },
+    },
+    {
+      name: 'ember-3.1.x',
+      npm: {
+        devDependencies: {
+          'ember-source': '~3.1.0',
+        },
+      },
+    },
+    {
+      name: 'ember-3.2.x',
+      npm: {
+        devDependencies: {
+          'ember-source': '~3.2.0',
         },
       },
     },

--- a/tests/dummy/app/components/no-yield-wrapper-with-own-children.jsx
+++ b/tests/dummy/app/components/no-yield-wrapper-with-own-children.jsx
@@ -1,0 +1,16 @@
+import React from 'npm:react';
+
+const NoYieldWrapperWithOwnChildren = props => {
+  if (React.Children.count(props.children)) {
+    throw new Error('There should be no child');
+  }
+
+  return (
+    <span>
+      <a>Link 1</a>
+      <a>Link 2</a>
+    </span>
+  );
+};
+
+export default NoYieldWrapperWithOwnChildren;

--- a/tests/dummy/app/components/no-yield-wrapper-with-props.jsx
+++ b/tests/dummy/app/components/no-yield-wrapper-with-props.jsx
@@ -1,0 +1,13 @@
+import React from 'npm:react';
+
+const NoYieldWrapperWithProps = props => {
+  const { text, children } = props;
+
+  if (React.Children.count(children)) {
+    throw new Error('There should be no child');
+  }
+
+  return <span>Rendered correctly with "{text}"</span>;
+};
+
+export default NoYieldWrapperWithProps;

--- a/tests/integration/components/react-component-test.js
+++ b/tests/integration/components/react-component-test.js
@@ -222,6 +222,25 @@ describeComponent(
       ).to.match(/^Rendered correctly$/);
     });
 
+    it('does not create YieldWrapper when there is no child, even after rerendering', function() {
+      this.set('text', 'show me!');
+      this.render(hbs`{{no-yield-wrapper-with-props text=text}}`);
+
+      // If YieldWrapper is created, it will not render correctly.
+      expect(
+        this.$()
+          .text()
+          .trim()
+      ).to.match(/^Rendered correctly with "show me!"$/);
+
+      this.set('text', 'rerender me!');
+      expect(
+        this.$()
+          .text()
+          .trim()
+      ).to.match(/^Rendered correctly with "rerender me!"$/);
+    });
+
     it('rerenders on state change', function() {
       this.render(hbs`{{react-component "say-hi" name=name}}`);
       this.set('name', 'Owen');

--- a/tests/integration/components/react-component-test.js
+++ b/tests/integration/components/react-component-test.js
@@ -253,6 +253,9 @@ describeComponent(
           .trim()
       ).to.match(/^Rendered correctly with "show me!"$/);
 
+      // This test is needed because on a re-render, there is already a
+      // non-comment child node (span) created by React. So simply checking
+      // single comment node won't work.
       this.set('text', 'rerender me!');
       expect(
         this.$()

--- a/tests/integration/components/react-component-test.js
+++ b/tests/integration/components/react-component-test.js
@@ -222,6 +222,26 @@ describeComponent(
       ).to.match(/^Rendered correctly$/);
     });
 
+    it('does not create YieldWrapper when there is no child, but the component has children inside', function() {
+      this.render(hbs`{{no-yield-wrapper-with-own-children}}`);
+
+      // If YieldWrapper is created, it will not render correctly.
+      const anchors = this.$('a');
+      expect(anchors.length).to.equals(2);
+      expect(
+        anchors
+          .eq(0)
+          .text()
+          .trim()
+      ).to.equals('Link 1');
+      expect(
+        anchors
+          .eq(1)
+          .text()
+          .trim()
+      ).to.equals('Link 2');
+    });
+
     it('does not create YieldWrapper when there is no child, even after rerendering', function() {
       this.set('text', 'show me!');
       this.render(hbs`{{no-yield-wrapper-with-props text=text}}`);


### PR DESCRIPTION
Fix #21.
Fix #28.

Several things were done:
- Added a `hasBlock` util to check if a component is in block form
- Update path to get `MUTABLE_CELL` in Ember 3.x
- Add more scenarios to ember-try