### PR TITLE
Migrate to CircleCI 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,36 +2,67 @@
 #
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
+
+# CircleCI maintains a library of pre-built images
+# documented at https://circleci.com/docs/2.0/circleci-images/
+
+# Default values
+defaults: &defaults
+  docker:
+    - image: circleci/node:6-browsers
+  working_directory: ~/ember-cli-react
+
 version: 2
 jobs:
-  build:
-    docker:
-      # specify the version you desire here
-      - image: circleci/node:6-browsers
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/mongo:3.4.4
-
-    working_directory: ~/ember-cli-react
-
+  checkout_code:
+    <<: *defaults
     steps:
       - checkout
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
 
+  install_dependencies:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
       # Download and cache dependencies
       - restore_cache:
           keys:
           - v1-dependencies-{{ checksum "package.json" }}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
-
-      - run: npm install
-
+      - run:
+          name: Install Packages
+          command: npm install
       - save_cache:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
 
-      # run tests!
-      - run: npm test
+  run_tests:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run Tests
+          command: ember test
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - checkout_code
+      - install_dependencies:
+          requires:
+            - checkout_code
+      - run_tests:
+          requires:
+            - install_dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,14 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: circleci/node:6-browsers
+    steps:
+      - checkout
+      - run:
+          name: Install Packages
+          command: npm install
+      - run:
+          name: Run Tests
+          command: npm test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,32 +109,60 @@ jobs:
           name: Run Tests
           command: ./node_modules/.bin/ember try:one ember-lts-2.18 --skip-cleanup=true
 
-  test_lts_3_0:
+  test_3_0:
     <<: *defaults
     steps:
       - attach_workspace:
           at: .
       - run:
           name: Run Tests
-          command: ./node_modules/.bin/ember try:one ember-lts-3.0 --skip-cleanup=true
+          command: ./node_modules/.bin/ember try:one ember-3.0 --skip-cleanup=true
 
-  test_lts_3_1:
+  test_3_1:
     <<: *defaults
     steps:
       - attach_workspace:
           at: .
       - run:
           name: Run Tests
-          command: ./node_modules/.bin/ember try:one ember-lts-3.1 --skip-cleanup=true
+          command: ./node_modules/.bin/ember try:one ember-3.1 --skip-cleanup=true
 
-  test_lts_3_2:
+  test_3_2:
     <<: *defaults
     steps:
       - attach_workspace:
           at: .
       - run:
           name: Run Tests
-          command: ./node_modules/.bin/ember try:one ember-lts-3.2 --skip-cleanup=true
+          command: ./node_modules/.bin/ember try:one ember-3.2 --skip-cleanup=true
+
+  test_release:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run Tests
+          command: ./node_modules/.bin/ember try:one ember-release --skip-cleanup=true
+
+
+  test_beta:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run Tests
+          command: ./node_modules/.bin/ember try:one ember-beta --skip-cleanup=true
+
+  test_canary:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run Tests
+          command: ./node_modules/.bin/ember try:one ember-canary --skip-cleanup=true
 
 workflows:
   version: 2
@@ -165,12 +193,12 @@ workflows:
       - test_lts_2_18:
           requires:
             - install_dependencies
-      - test_lts_3_0:
+      - test_3_0:
           requires:
             - install_dependencies
-      - test_lts_3_1:
+      - test_3_1:
           requires:
             - install_dependencies
-      - test_lts_3_2:
+      - test_3_2:
           requires:
             - install_dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,20 +14,10 @@ defaults: &defaults
 
 version: 2
 jobs:
-  checkout_code:
+  setup_environment:
     <<: *defaults
     steps:
       - checkout
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .
-
-  install_dependencies:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: .
       # Download and cache dependencies
       - restore_cache:
           keys:
@@ -168,46 +158,43 @@ workflows:
   version: 2
   test:
     jobs:
-      - checkout_code
-      - install_dependencies:
-          requires:
-            - checkout_code
+      - setup_environment
       - test_1_13:
           requires:
-            - install_dependencies
+            - setup_environment
       - test_lts_2_4:
           requires:
-            - install_dependencies
+            - setup_environment
       - test_lts_2_8:
           requires:
-            - install_dependencies
+            - setup_environment
       - test_2_10:
           requires:
-            - install_dependencies
+            - setup_environment
       - test_lts_2_12:
           requires:
-            - install_dependencies
+            - setup_environment
       - test_lts_2_16:
           requires:
-            - install_dependencies
+            - setup_environment
       - test_lts_2_18:
           requires:
-            - install_dependencies
+            - setup_environment
       - test_3_0:
           requires:
-            - install_dependencies
+            - setup_environment
       - test_3_1:
           requires:
-            - install_dependencies
+            - setup_environment
       - test_3_2:
           requires:
-            - install_dependencies
+            - setup_environment
       - test_release:
           requires:
-            - install_dependencies
+            - setup_environment
       - test_beta:
           requires:
-            - install_dependencies
+            - setup_environment
       - test_canary:
           requires:
-            - install_dependencies
+            - setup_environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,14 +46,23 @@ jobs:
           paths:
             - .
 
-  run_tests:
+  test_lts_2_8:
     <<: *defaults
     steps:
       - attach_workspace:
           at: .
       - run:
           name: Run Tests
-          command: npm test
+          command: ./node_modules/.bin/ember try:one ember-lts-2.8 --skip-cleanup=true
+
+  test_lts_2_12:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run Tests
+          command: ./node_modules/.bin/ember try:one ember-lts-2.12 --skip-cleanup=true
 
 workflows:
   version: 2
@@ -63,6 +72,9 @@ workflows:
       - install_dependencies:
           requires:
             - checkout_code
-      - run_tests:
+      - test_lts_2_8:
+          requires:
+            - install_dependencies
+      - test_lts_2_12:
           requires:
             - install_dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           at: .
       - run:
           name: Run Tests
-          command: ember test
+          command: npm test
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,24 @@ jobs:
           paths:
             - .
 
+  test_1_13:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run Tests
+          command: ./node_modules/.bin/ember try:one ember-1.13 --skip-cleanup=true
+
+  test_lts_2_4:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run Tests
+          command: ./node_modules/.bin/ember try:one ember-lts-2.4 --skip-cleanup=true
+
   test_lts_2_8:
     <<: *defaults
     steps:
@@ -54,6 +72,15 @@ jobs:
       - run:
           name: Run Tests
           command: ./node_modules/.bin/ember try:one ember-lts-2.8 --skip-cleanup=true
+
+  test_2_10:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run Tests
+          command: ./node_modules/.bin/ember try:one ember-2.10 --skip-cleanup=true
 
   test_lts_2_12:
     <<: *defaults
@@ -64,6 +91,51 @@ jobs:
           name: Run Tests
           command: ./node_modules/.bin/ember try:one ember-lts-2.12 --skip-cleanup=true
 
+  test_lts_2_16:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run Tests
+          command: ./node_modules/.bin/ember try:one ember-lts-2.16 --skip-cleanup=true
+
+  test_lts_2_18:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run Tests
+          command: ./node_modules/.bin/ember try:one ember-lts-2.18 --skip-cleanup=true
+
+  test_lts_3_0:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run Tests
+          command: ./node_modules/.bin/ember try:one ember-lts-3.0 --skip-cleanup=true
+
+  test_lts_3_1:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run Tests
+          command: ./node_modules/.bin/ember try:one ember-lts-3.1 --skip-cleanup=true
+
+  test_lts_3_2:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run Tests
+          command: ./node_modules/.bin/ember try:one ember-lts-3.2 --skip-cleanup=true
+
 workflows:
   version: 2
   test:
@@ -72,9 +144,33 @@ workflows:
       - install_dependencies:
           requires:
             - checkout_code
+      - test_1_13:
+        requires:
+          - install_dependencies
+      - test_lts_2_4:
+        requires:
+          - install_dependencies
       - test_lts_2_8:
-          requires:
-            - install_dependencies
+        requires:
+          - install_dependencies
+      - test_2_10:
+        requires:
+          - install_dependencies
       - test_lts_2_12:
-          requires:
-            - install_dependencies
+        requires:
+          - install_dependencies
+      - test_lts_2_16:
+        requires:
+          - install_dependencies
+      - test_lts_2_18:
+        requires:
+          - install_dependencies
+      - test_lts_3_0:
+        requires:
+          - install_dependencies
+      - test_lts_3_1:
+        requires:
+          - install_dependencies
+      - test_lts_3_2:
+        requires:
+          - install_dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,39 @@
+# Javascript Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
 version: 2
-
 jobs:
   build:
     docker:
+      # specify the version you desire here
       - image: circleci/node:6-browsers
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/mongo:3.4.4
+
+    working_directory: ~/ember-cli-react
+
     steps:
       - checkout
-      - run:
-          name: Install Packages
-          command: npm install
-      - run:
-          name: Run Tests
-          command: npm test
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: npm install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      # run tests!
+      - run: npm test
+
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,5 +35,3 @@ jobs:
 
       # run tests!
       - run: npm test
-
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,32 +145,32 @@ workflows:
           requires:
             - checkout_code
       - test_1_13:
-        requires:
-          - install_dependencies
+          requires:
+            - install_dependencies
       - test_lts_2_4:
-        requires:
-          - install_dependencies
+          requires:
+            - install_dependencies
       - test_lts_2_8:
-        requires:
-          - install_dependencies
+          requires:
+            - install_dependencies
       - test_2_10:
-        requires:
-          - install_dependencies
+          requires:
+            - install_dependencies
       - test_lts_2_12:
-        requires:
-          - install_dependencies
+          requires:
+            - install_dependencies
       - test_lts_2_16:
-        requires:
-          - install_dependencies
+          requires:
+            - install_dependencies
       - test_lts_2_18:
-        requires:
-          - install_dependencies
+          requires:
+            - install_dependencies
       - test_lts_3_0:
-        requires:
-          - install_dependencies
+          requires:
+            - install_dependencies
       - test_lts_3_1:
-        requires:
-          - install_dependencies
+          requires:
+            - install_dependencies
       - test_lts_3_2:
-        requires:
-          - install_dependencies
+          requires:
+            - install_dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,3 +202,12 @@ workflows:
       - test_3_2:
           requires:
             - install_dependencies
+      - test_release:
+          requires:
+            - install_dependencies
+      - test_beta:
+          requires:
+            - install_dependencies
+      - test_canary:
+          requires:
+            - install_dependencies

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-machine:
-  node:
-    version: 6.10.3

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,6 +2,22 @@
 module.exports = {
   scenarios: [
     {
+      name: 'ember-1.13',
+      bower: {
+        dependencies: {
+          ember: '~1.13.0',
+        },
+      },
+    },
+    {
+      name: 'ember-lts-2.4',
+      bower: {
+        dependencies: {
+          ember: '~2.4.0',
+        },
+      },
+    },
+    {
       name: 'ember-lts-2.8',
       bower: {
         dependencies: {
@@ -17,11 +33,60 @@ module.exports = {
         },
       },
     },
+    // Glimmer was introduced in v2.10, so better test it
+    {
+      name: 'ember-2.10',
+      bower: {
+        dependencies: {
+          ember: '~2.10.0',
+        },
+      },
+    },
     {
       name: 'ember-lts-2.12',
       npm: {
         devDependencies: {
           'ember-source': '~2.12.0',
+        },
+      },
+    },
+    {
+      name: 'ember-lts-2.16',
+      npm: {
+        devDependencies: {
+          'ember-source': '~2.16.0',
+        },
+      },
+    },
+    {
+      name: 'ember-lts-2.18',
+      npm: {
+        devDependencies: {
+          'ember-source': '~2.18.0',
+        },
+      },
+    },
+    {
+      name: 'ember-3.0',
+      npm: {
+        devDependencies: {
+          'ember-source': '~3.0.0',
+        },
+      },
+    },
+    {
+      name: 'ember-3.1',
+      npm: {
+        devDependencies: {
+          'ember-source': '~3.1.0',
+        },
+      },
+    },
+    {
+      name: 'ember-3.2',
+      npm: {
+        devDependencies: {
+          'ember-source': '~3.2.0',
         },
       },
     },


### PR DESCRIPTION
Fix #25.

This migrates conflict to CircleCI 2. At the same time it configures workflow for simultaneous tests for each Ember version