### PR TITLE
Install `ember-auto-import` to Ember App during `ember install`

### DIFF
--- a/blueprints/ember-cli-react/index.js
+++ b/blueprints/ember-cli-react/index.js
@@ -2,6 +2,13 @@
 
 var pkg = require('../../package.json');
 
+function getDependencyVersion(packageJson, name) {
+  var dependencies = packageJson.dependencies;
+  var devDependencies = packageJson.devDependencies;
+
+  return dependencies[name] || devDependencies[name];
+}
+
 function getPeerDependencyVersion(packageJson, name) {
   var peerDependencies = packageJson.peerDependencies;
 
@@ -16,6 +23,10 @@ module.exports = {
   // Install react into host app
   afterInstall: function() {
     const packages = [
+      {
+        name: 'ember-auto-import',
+        target: getDependencyVersion(pkg, 'ember-auto-import'),
+      },
       {
         name: 'react',
         target: getPeerDependencyVersion(pkg, 'react'),


### PR DESCRIPTION
This was removed half-way of #27 because React and ReactDom can still be successfully imported without the Ember App to have `ember-auto-import` as dependency. However, it is very likely for users of `ember-cli-react` to use other libraries (e.g. `prop-types`, `react-redux`, etc) together. Without `ember-auto-import`, it won't work.

Therefore I think it is pretty useful to install it for addon users by default.