### PR TITLE
Remove react and react-dom from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,14 +59,14 @@
     "husky": "^0.14.3",
     "lint-staged": "^5.0.0",
     "loader.js": "^4.2.3",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
     "prettier": "^1.9.2"
   },
   "dependencies": {
     "broccoli-react": "^0.8.0",
     "ember-auto-import": "^1.0.1",
-    "ember-cli-babel": "^6.3.0",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4"
+    "ember-cli-babel": "^6.3.0"
   },
   "peerDependencies": {
     "react": "^15.5.4 || ^16.0.0",


### PR DESCRIPTION
This fixes the following issue that Ember doesn't want to build.

```
ember-cli-react and client are using different versions of react (15.6.2 located at
/Users/levrik/code/*****/node_modules/ember-cli-react/node_modules/react/react.js vs 16.5.2 located
at /Users/levrik/code/*****/node_modules/react/index.js)
```