### PR TITLE
Put React peerDependencies version ranges also on dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
     "broccoli-react": "^0.8.0",
     "ember-auto-import": "^1.0.1",
     "ember-cli-babel": "^6.3.0",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4"
+    "react": "^15.5.4 || ^16.0.0",
+    "react-dom": "^15.5.4 || ^16.0.0"
   },
   "peerDependencies": {
     "react": "^15.5.4 || ^16.0.0",


### PR DESCRIPTION
This fixes the issue of having two different versions of React installed if you install React v16 on the app level.
Before this change React v15 was always installed by ember-cli-react.
Before ember-cli-react@1.0.1 also the installed React version on app level was ignored completely.