### PR TITLE
Allows to configure babel options via ember-cli-build

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   root: true,
+  parser: 'babel-eslint',
   parserOptions: {
     ecmaFeatures: {
       jsx: true,

--- a/README.md
+++ b/README.md
@@ -231,23 +231,23 @@ For Babel 6,
    });
    ```
 
-````
 For Babel 7,
 
 1. Install the transforms `npm install --save-dev @babel/plugin-proposal-object-rest-spread @babel/plugin-proposal-class-properties`
 2. Add these plugins to your `ember-cli-build.js` file
- ```js
- let app = new EmberAddon(defaults, {
+
+```js
+let app = new EmberAddon(defaults, {
   'ember-cli-react': {
     babelOptions: {
       plugins: [
         '@babel/plugin-proposal-object-rest-spread',
-        '@babel/plugin-proposal-class-properties'
+        '@babel/plugin-proposal-class-properties',
       ],
-    }
+    },
   },
 });
-````
+```
 
 ## What's Missing
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,45 @@ export default class TodoItem extends React.Component {
 }
 ```
 
+## Object Rest Spread and Class Properties
+
+[Object Rest Spread]() and [Class Properties](https://babeljs.io/docs/en/babel-plugin-proposal-class-properties) are included in `create-react-app` and used in many React projects. To enable these features in your React components, you must configure the Babel compiler used by `ember-cli-react`. You can do this by passing `babelOptions` to `ember-cli-react` configurations.
+
+For Babel 6,
+
+1. Add Babel plugin packages to your project `babel-plugin-transform-object-rest-spread` and `babel-plugin-transform-class-properties`
+2. In `ember-cli-build.js` file, configure
+   ```js
+   let app = new EmberApp(defaults, {
+     'ember-cli-react': {
+       babelOptions: {
+         plugins: [
+           'transform-class-properties',
+           'transform-object-rest-spread',
+         ],
+       },
+     },
+   });
+   ```
+
+````
+For Babel 7,
+
+1. Install the transforms `npm install --save-dev @babel/plugin-proposal-object-rest-spread @babel/plugin-proposal-class-properties`
+2. Add these plugins to your `ember-cli-build.js` file
+ ```js
+ let app = new EmberAddon(defaults, {
+  'ember-cli-react': {
+    babelOptions: {
+      plugins: [
+        '@babel/plugin-proposal-object-rest-spread',
+        '@babel/plugin-proposal-class-properties'
+      ],
+    }
+  },
+});
+````
+
 ## What's Missing
 
 There is no React `link-to` equivalent for linking to Ember routes inside of

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ export default class TodoItem extends React.Component {
 
 ## Object Rest Spread and Class Properties
 
-[Object Rest Spread]() and [Class Properties](https://babeljs.io/docs/en/babel-plugin-proposal-class-properties) are included in `create-react-app` and used in many React projects. To enable these features in your React components, you must configure the Babel compiler used by `ember-cli-react`. You can do this by passing `babelOptions` to `ember-cli-react` configurations.
+[Object Rest Spread]() and [Class Properties](https://babeljs.io/docs/en/babel-plugin-proposal-class-properties) are included in `create-react-app` and used in many React projects. To enable these features you must add respective transforms to Babel plugins setting in your `ember-cli-build.js`.
 
 For Babel 6,
 
@@ -220,13 +220,8 @@ For Babel 6,
 2. In `ember-cli-build.js` file, configure
    ```js
    let app = new EmberApp(defaults, {
-     'ember-cli-react': {
-       babelOptions: {
-         plugins: [
-           'transform-class-properties',
-           'transform-object-rest-spread',
-         ],
-       },
+     babel: {
+       plugins: ['transform-class-properties', 'transform-object-rest-spread'],
      },
    });
    ```
@@ -238,13 +233,11 @@ For Babel 7,
 
 ```js
 let app = new EmberAddon(defaults, {
-  'ember-cli-react': {
-    babelOptions: {
-      plugins: [
-        '@babel/plugin-proposal-object-rest-spread',
-        '@babel/plugin-proposal-class-properties',
-      ],
-    },
+  babel: {
+    plugins: [
+      '@babel/plugin-proposal-object-rest-spread',
+      '@babel/plugin-proposal-class-properties',
+    ],
   },
 });
 ```

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -8,6 +8,11 @@ module.exports = function(defaults) {
     'ember-cli-babel': {
       includePolyfill: true,
     },
+    'ember-cli-react': {
+      babelOptions: {
+        plugins: ['transform-class-properties', 'transform-object-rest-spread'],
+      },
+    },
   });
 
   /*

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -8,10 +8,8 @@ module.exports = function(defaults) {
     'ember-cli-babel': {
       includePolyfill: true,
     },
-    'ember-cli-react': {
-      babelOptions: {
-        plugins: ['transform-class-properties', 'transform-object-rest-spread'],
-      },
+    babel: {
+      plugins: ['transform-class-properties', 'transform-object-rest-spread'],
     },
   });
 

--- a/index.js
+++ b/index.js
@@ -6,9 +6,44 @@ const react = require('broccoli-react');
 module.exports = {
   name: 'ember-cli-react',
 
-  preprocessTree: function(type, tree) {
+  appOptions() {
+    return (
+      (this.parent && this.parent.options) || (this.app && this.app.options)
+    );
+  },
+
+  included() {
+    let app;
+
+    // @source: https://github.com/samselikoff/ember-cli-mirage/blob/master/index.js#L34
+    // If the addon has the _findHost() method (in ember-cli >= 2.7.0), we'll just
+    // use that.
+    if (typeof this._findHost === 'function') {
+      app = this._findHost();
+    } else {
+      // Otherwise, we'll use this implementation borrowed from the _findHost()
+      // method in ember-cli.
+      let current = this;
+      do {
+        app = current.app || app;
+      } while (current.parent.parent && (current = current.parent));
+    }
+
+    this.app = app;
+    this.addonBuildConfig = this.app.options['ember-cli-react'] || {
+      babelOptions: {},
+    };
+
+    this._super.included.apply(this, arguments);
+  },
+
+  preprocessTree(type, tree) {
     if (type === 'js') {
-      tree = react(tree, { transform: { es6module: true } });
+      let { babelOptions } = this.addonBuildConfig;
+      tree = react(tree, {
+        transform: { es6module: true },
+        babelOptions,
+      });
     }
 
     return tree;

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = {
           },
         });
 
-        // apply preprocessing from other babel plugins
+        // apply preprocessing from other babel plugins to the jsx files
         let processed = parent.registry
           .load('js')
           .filter(p => p.name !== 'ember-cli-react')

--- a/lib/configure-jsx-transform.js
+++ b/lib/configure-jsx-transform.js
@@ -1,0 +1,43 @@
+const VersionChecker = require('ember-cli-version-checker');
+
+function requireTransform(transformName) {
+  return require.resolve(transformName);
+}
+
+function hasPlugin(plugins, name) {
+  for (const maybePlugin of plugins) {
+    const plugin = Array.isArray(maybePlugin) ? maybePlugin[0] : maybePlugin;
+    const pluginName = typeof plugin === 'string' ? plugin : plugin.name;
+
+    if (pluginName === name) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+module.exports = function configureJsxTransform(parent) {
+  const options = (parent.options = parent.options || {});
+
+  const checker = new VersionChecker(parent).for('ember-cli-babel', 'npm');
+
+  options.babel = options.babel || {};
+  options.babel.plugins = options.babel.plugins || [];
+
+  if (checker.satisfies('^6.0.0-beta.1')) {
+    if (!hasPlugin(options.babel.plugins, 'babel-plugin-transform-react-jsx')) {
+      options.babel.plugins.push(
+        requireTransform('babel-plugin-transform-react-jsx')
+      );
+    }
+  } else if (checker.gte('7.0.0')) {
+    if (
+      !hasPlugin(options.babel.plugins, '@babel/plugin-transform-react-jsx')
+    ) {
+      options.babel.plugins.push(
+        requireTransform('@babel/plugin-transform-react-jsx')
+      );
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "author": "alex@altschool.com",
   "license": "MIT",
   "devDependencies": {
+    "babel-eslint": "10.0.1",
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~2.15.1",
@@ -59,10 +60,12 @@
     "husky": "^0.14.3",
     "lint-staged": "^5.0.0",
     "loader.js": "^4.2.3",
-    "prettier": "^1.9.2"
+    "prettier": "^1.9.2",
+    "babel-plugin-transform-class-properties": "6.24.1",
+    "babel-plugin-transform-object-rest-spread": "6.26.0"
   },
   "dependencies": {
-    "broccoli-react": "^0.8.0",
+    "broccoli-react": "eddhannay/broccoli-react#1399c761da19aff4492a521a1b4d53429433e499",
     "ember-auto-import": "^1.0.1",
     "ember-cli-babel": "^6.3.0",
     "react": "^15.5.4 || ^16.0.0",

--- a/package.json
+++ b/package.json
@@ -62,10 +62,14 @@
     "loader.js": "^4.2.3",
     "prettier": "^1.9.2",
     "babel-plugin-transform-class-properties": "6.24.1",
-    "babel-plugin-transform-object-rest-spread": "6.26.0"
+    "babel-plugin-transform-object-rest-spread": "6.26.0",
+    "broccoli-funnel": "2.0.1",
+    "broccoli-merge-trees": "3.0.1",
+    "ember-cli-version-checker": "^2.1.2"
   },
   "dependencies": {
-    "broccoli-react": "eddhannay/broccoli-react#1399c761da19aff4492a521a1b4d53429433e499",
+    "@babel/plugin-transform-react-jsx": "^7.0.0",
+    "babel-plugin-transform-react-jsx": "^6.24.1",
     "ember-auto-import": "^1.0.1",
     "ember-cli-babel": "^6.3.0",
     "react": "^15.5.4 || ^16.0.0",

--- a/tests/dummy/app/components/babel-features.jsx
+++ b/tests/dummy/app/components/babel-features.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 class State {
-  message = 'supports clsss properties';
+  message = 'supports class properties';
 }
 
 export default function BabelFeatures() {

--- a/tests/dummy/app/components/babel-features.jsx
+++ b/tests/dummy/app/components/babel-features.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+class State {
+  message = 'supports clsss properties';
+}
+
+export default function BabelFeatures() {
+  let attrs = { 'data-test': 'allows-object-spread' };
+  let s = new State();
+  return <div {...attrs}>{s.message}</div>;
+}

--- a/tests/integration/components/react-component-test.js
+++ b/tests/integration/components/react-component-test.js
@@ -20,6 +20,13 @@ describeComponent(
       expect(this.$()).to.have.length(1);
     });
 
+    it('uses babel features', function() {
+      this.render(hbs`{{react-component "babel-features"}}`);
+      expect(this.$('[data-test="allows-object-spread"]').text()).to.equal(
+        'supports clsss properties'
+      );
+    });
+
     it.skip('throws error when no component found', function() {
       expect(() => {
         this.render(hbs`{{react-component "missing-component"}}`);

--- a/tests/integration/components/react-component-test.js
+++ b/tests/integration/components/react-component-test.js
@@ -23,7 +23,7 @@ describeComponent(
     it('uses babel features', function() {
       this.render(hbs`{{react-component "babel-features"}}`);
       expect(this.$('[data-test="allows-object-spread"]').text()).to.equal(
-        'supports clsss properties'
+        'supports class properties'
       );
     });
 


### PR DESCRIPTION
# Purpose

Object Rest Spread and Class Properties are transforms that are included with `create-react-app`. As such, they're considered common features in React applications. `ember-cli-react` doesn't allow these features to be used in `JSX` which limits capabilities for developers who're used to using these features in React applications.

# Approach

This PR removes `broccoli-react` in favour of using EmberCLI's Babel Preprocessor. This makes it possible to configure JSX by adding transforms to the babel configuration in `ember-cli-build.js`. Here is an example of this file with several plugins installed.

```js
const EmberApp = require('ember-cli/lib/broccoli/ember-app');

module.exports = function(defaults) {
  let app = new EmberApp(defaults, {
    babel: {
      plugins: [
        'transform-decorators-legacy',
        'transform-object-rest-spread',
        'transform-class-properties'
      ]
    }
  });

  return app.toTree();
};
```

# TODO

- [x] Added information about adding plugins to README
- ~[ ] Wait for broccoli-react 0.9.0 to be released https://github.com/eddhannay/broccoli-react/issues/12~
- ~[ ] Confirm the configuration API~

# ~Unresolved~

(Not relevant anymore)

This PR adds a new way to configure a Babel compiler with new options. Here is an example of adding 3 plugins to the Ember babel and `ember-cli-react`'s babel.

```js
const EmberApp = require('ember-cli/lib/broccoli/ember-app');

module.exports = function(defaults) {
  let app = new EmberApp(defaults, {
    babel: {
      plugins: [
        'transform-decorators-legacy',
        'transform-object-rest-spread',
        'transform-class-properties'
      ]
    },
    'ember-cli-react': {
      babelOptions: {
        plugins: [
          'transform-decorators-legacy',
          'transform-object-rest-spread',
          'transform-class-properties'
        ]
      },
    },
  });

  return app.toTree();
};
```

Adding another way to configure Babel is 💩. It would be better to use Ember's Babel compiler but that might require changes to `broccoli-react` or a different approach to adding JSX to the Ember app. Alternative approach would be to drop `broccoli-react` in favour of adding JSX plugin to Ember's babel compiler. I'm not sure what impact that would have, so I'd like to open this to discussion.