### PR TITLE
OS-83133: opt-in synchronous React mounts via flushSync predicate

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 /bower_components
+/node_modules
 /config/ember-try.js
 /dist
 /tests

--- a/addon/components/react-component.js
+++ b/addon/components/react-component.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import YieldWrapper from './react-component/yield-wrapper';
 
 import getMutableAttributes from 'ember-cli-react/utils/get-mutable-attributes';
@@ -10,6 +10,7 @@ import lookupFactory from 'ember-cli-react/utils/lookup-factory';
 const { get } = Ember;
 
 const ReactComponent = Ember.Component.extend({
+  _rootElem: null,
   /**
     The React component that this Ember component should wrap.
 
@@ -76,14 +77,17 @@ const ReactComponent = Ember.Component.extend({
       }
     }
 
-    ReactDOM.render(
-      React.createElement(componentClass, props, children),
+    const component = React.createElement(componentClass, props, children);
+    this._rootElem = ReactDOM.createRoot(
       get(this, 'element')
     );
+
+    this._rootElem.render(component);
   },
 
   willDestroyElement: function() {
-    ReactDOM.unmountComponentAtNode(get(this, 'element'));
+    this._rootElem.unmount();
+    // ReactDOM.unmountComponentAtNode(get(this, 'element'));
   },
 });
 

--- a/addon/components/react-component.js
+++ b/addon/components/react-component.js
@@ -1,10 +1,12 @@
 import Ember from 'ember';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { flushSync } from 'react-dom';
 import YieldWrapper from './react-component/yield-wrapper';
 import getMutableAttributes from 'ember-cli-react/utils/get-mutable-attributes';
 import hasBlock from 'ember-cli-react/utils/has-block';
 import lookupFactory from 'ember-cli-react/utils/lookup-factory';
+import { shouldSyncMount } from 'ember-cli-react/utils/sync-mount';
 
 const { get } = Ember;
 
@@ -86,7 +88,12 @@ const ReactComponent = Ember.Component.extend({
     const children = this.getChildren(props);
     const component = React.createElement(componentClass, props, children);
     if (this._rootElem) {
-      this._rootElem.render(component);
+      const name = get(this, '_reactComponent');
+      if (typeof name === 'string' && shouldSyncMount(name)) {
+        flushSync(() => this._rootElem.render(component));
+      } else {
+        this._rootElem.render(component);
+      }
     }
   },
 

--- a/addon/components/react-component.js
+++ b/addon/components/react-component.js
@@ -88,7 +88,7 @@ const ReactComponent = Ember.Component.extend({
     const children = this.getChildren(props);
     const component = React.createElement(componentClass, props, children);
     if (this._rootElem) {
-      const name = get(this, '_reactComponent');
+      const name = get(this, '_resolvedName') || get(this, '_reactComponent');
       if (typeof name === 'string' && shouldSyncMount(name)) {
         flushSync(() => this._rootElem.render(component));
       } else {

--- a/addon/resolver.js
+++ b/addon/resolver.js
@@ -28,6 +28,7 @@ export default Resolver.extend({
       // This enables using React Components directly in template
       return ReactComponent.extend({
         reactComponent: result,
+        _resolvedName: parsedName.fullNameWithoutType,
       });
     }
   },

--- a/addon/utils/sync-mount.js
+++ b/addon/utils/sync-mount.js
@@ -1,0 +1,22 @@
+// Opt-in mechanism to force synchronous React mounts for selected components.
+//
+// React 18's createRoot().render() schedules work via React's concurrent
+// scheduler, which yields between roots. When an Ember template contains
+// many sibling {{[name]}} React invocations, each root's mount + paint +
+// passive-effect cycle completes before the next root's render starts,
+// producing a visible "wave" effect (see Optibus OS-83133).
+//
+// Host apps can register a predicate via setSyncMountPredicate; when the
+// predicate returns true for a resolved component name, that mount wraps
+// the .render() call in flushSync so all matching siblings mount in the
+// same task and the browser paints once.
+
+let predicate = () => false;
+
+export function setSyncMountPredicate(fn) {
+  predicate = typeof fn === 'function' ? fn : () => false;
+}
+
+export function shouldSyncMount(name) {
+  return predicate(name);
+}

--- a/package.json
+++ b/package.json
@@ -66,11 +66,11 @@
     "ember-auto-import": "^1.0.1",
     "ember-cli-babel": "^6.3.0",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1",
+    "react-dom": "^17.0.1"
   },
   "peerDependencies": {
     "react": "^17.0.1",
-    "react-dom": "^17.0.1",
+    "react-dom": "^17.0.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -65,12 +65,12 @@
     "broccoli-react": "^0.8.0",
     "ember-auto-import": "^1.0.1",
     "ember-cli-babel": "^6.3.0",
-    "react": "^15.5.4 || ^16.0.0",
-    "react-dom": "^15.5.4 || ^16.0.0"
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
   },
   "peerDependencies": {
-    "react": "^15.5.4 || ^16.0.0",
-    "react-dom": "^15.5.4 || ^16.0.0"
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-react",
-  "version": "1.0.2",
+  "version": "2.0.2",
   "description": "Use React component hierarchies in your Ember app.",
   "keywords": [
     "ember-addon"

--- a/package.json
+++ b/package.json
@@ -65,12 +65,12 @@
     "broccoli-react": "^0.8.0",
     "ember-auto-import": "^1.0.1",
     "ember-cli-babel": "^6.3.0",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "peerDependencies": {
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
## Summary

- Adds `setSyncMountPredicate` (in `addon/utils/sync-mount.js`) so host apps can opt specific components into synchronous React 18 mounts. When the predicate returns true for a resolved component name, that mount wraps `root.render()` in `flushSync`, so all matching siblings mount in the same task and the browser paints once instead of producing a visible mount cascade.
- Stashes `parsedName.fullNameWithoutType` as `_resolvedName` on the wrapped `ReactComponent` subclass during resolution, and prefers it over `_reactComponent` at render time. Without this, the predicate only ever saw a name for `{{react-component "foo"}}` positional invocations; for the common resolver-driven path (`{{my-react-comp}}`, PascalCase, DI-registered components) `_reactComponent` is always undefined and the feature never engaged.

## Test plan

- [ ] In a host app, call `setSyncMountPredicate(name => name === 'my-react-comp')`, render a template that mounts many `{{my-react-comp}}` siblings, and confirm they all paint in one frame.
- [ ] Confirm components for which the predicate returns false still mount via the default async `root.render()` path.
- [ ] Confirm `{{react-component "foo"}}` positional invocations still pass `"foo"` to the predicate.
- [ ] Confirm non-React Ember components (which return early in the resolver's `isComponentFactory` branch) are unaffected.